### PR TITLE
Feat/add dead letter queue

### DIFF
--- a/src/main/kotlin/com/okp4/processor/cosmos/topology.kt
+++ b/src/main/kotlin/com/okp4/processor/cosmos/topology.kt
@@ -3,7 +3,7 @@ package com.okp4.processor.cosmos
 import org.apache.kafka.common.serialization.Serdes
 import org.apache.kafka.streams.StreamsBuilder
 import org.apache.kafka.streams.Topology
-import org.apache.kafka.streams.kstream.Branched
+import org.apache.kafka.streams.kstream.Branched.*
 import org.apache.kafka.streams.kstream.Consumed
 import org.apache.kafka.streams.kstream.Named
 import org.apache.kafka.streams.kstream.Produced
@@ -39,7 +39,7 @@ fun topology(props: Properties): Topology {
                 }, Named.`as`("map-value"))
                     .split().branch(
                         { _, v -> v.second.isFailure },
-                        Branched.withConsumer { ks ->
+                        withConsumer { ks ->
                             ks.peek(
                                 { k, v ->
                                     v.second.onFailure {
@@ -60,7 +60,7 @@ fun topology(props: Properties): Topology {
                         }
                     )
                     .defaultBranch(
-                        Branched.withConsumer { ks ->
+                        withConsumer { ks ->
                             ks.mapValues(
                                 { v -> v.second.getOrThrow() }, Named.`as`("unwrap-value")
                                 ).to(

--- a/src/main/kotlin/com/okp4/processor/cosmos/topology.kt
+++ b/src/main/kotlin/com/okp4/processor/cosmos/topology.kt
@@ -1,9 +1,9 @@
 package com.okp4.processor.cosmos
 
 import org.apache.kafka.common.serialization.Serdes
-import org.apache.kafka.streams.KeyValue
 import org.apache.kafka.streams.StreamsBuilder
 import org.apache.kafka.streams.Topology
+import org.apache.kafka.streams.kstream.Branched
 import org.apache.kafka.streams.kstream.Consumed
 import org.apache.kafka.streams.kstream.Named
 import org.apache.kafka.streams.kstream.Produced
@@ -21,12 +21,53 @@ fun topology(props: Properties): Topology {
     val topicOut = requireNotNull(props.getProperty("topic.out")) {
         "Option 'topic.out' was not specified."
     }
+    val topicError: String? = props.getProperty("topic.error")
 
     return StreamsBuilder()
         .apply {
             stream(topicIn, Consumed.with(Serdes.String(), Serdes.String()).withName("input"))
                 .peek({ _, _ -> logger.info("Received a message") }, Named.`as`("log"))
-                .map({ k, v -> KeyValue(k, "Hello $v!") }, Named.`as`("map-value"))
-                .to(topicOut, Produced.with(Serdes.String(), Serdes.String()).withName("output"))
-        }.build()
-}
+                .mapValues({ v ->
+                    Pair(
+                        v,
+                        runCatching {
+                            require(!v.isNullOrBlank()) { "Message cannot be blank" }
+
+                            "Hello $v!"
+                        }
+                    )
+                }, Named.`as`("map-value"))
+                    .split().branch(
+                        { _, v -> v.second.isFailure },
+                        Branched.withConsumer { ks ->
+                            ks.peek(
+                                { k, v ->
+                                    v.second.onFailure {
+                                        logger.warn("Deserialization failed for block with key <$k>: ${it.message}", it)
+                                    }
+                                },
+                                Named.`as`("log-failure")
+                            )
+                                .mapValues { v -> v.first }
+                                .apply {
+                                    if (!topicError.isNullOrEmpty()) {
+                                        logger.info("Failed block will be sent to the topic $topicError")
+                                        to(
+                                            topicError, Produced.with(Serdes.String(), Serdes.String()).withName("error")
+                                        )
+                                    }
+                                }
+                        }
+                    )
+                    .defaultBranch(
+                        Branched.withConsumer { ks ->
+                            ks.mapValues(
+                                { v -> v.second.getOrThrow() }, Named.`as`("unwrap-value")
+                                ).to(
+                                    topicOut, Produced.with(Serdes.String(), Serdes.String()).withName("output")
+                                )
+                            }
+                        )
+                }.build()
+        }
+        

--- a/src/test/kotlin/com/okp4/processor/cosmos/TopologyTest.kt
+++ b/src/test/kotlin/com/okp4/processor/cosmos/TopologyTest.kt
@@ -1,7 +1,10 @@
 package com.okp4.processor.cosmos
 
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.datatest.withData
+import io.kotest.data.forAll
+import io.kotest.data.headers
+import io.kotest.data.row
+import io.kotest.data.table
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.apache.kafka.common.serialization.Serdes
@@ -14,7 +17,8 @@ class TopologyTest : BehaviorSpec({
         StreamsConfig.APPLICATION_ID_CONFIG to "simple",
         StreamsConfig.BOOTSTRAP_SERVERS_CONFIG to "dummy:1234",
         "topic.in" to "in",
-        "topic.out" to "out"
+        "topic.out" to "out",
+        "topic.error" to "error"
     ).toProperties()
 
     given("A topology") {
@@ -22,21 +26,23 @@ class TopologyTest : BehaviorSpec({
         val testDriver = TopologyTestDriver(topology, config)
         val inputTopic = testDriver.createInputTopic("in", stringSerde.serializer(), stringSerde.serializer())
         val outputTopic = testDriver.createOutputTopic("out", stringSerde.deserializer(), stringSerde.deserializer())
+        val errorTopic = testDriver.createOutputTopic("error", stringSerde.deserializer(), stringSerde.deserializer())
 
-        withData(
-            mapOf(
-                "simple message" to arrayOf("John Doe", "Hello John Doe!"),
-                "empty message" to arrayOf("", "Hello !"),
-            )
-        ) { (message, expectedMessage) ->
-            When("sending the message <$message> to the input topic ($inputTopic)") {
+        table(
+            headers("case", "message", "isError", "expected"),
+            row("simple message", "John Doe", false, "Hello John Doe!"),
+            row("empty message", "  ", true, "  "),
+        ).forAll { case, message, isError, expected ->
+            When("sending the message <$message> to the input topic ($inputTopic) ($case)") {
                 inputTopic.pipeInput("", message)
 
-                then("message is received from the output topic ($outputTopic)") {
-                    val result = outputTopic.readKeyValue()
+                val topic = if (isError) errorTopic else outputTopic
+
+                then("message is received from the output topic ($topic)") {
+                    val result = topic.readKeyValue()
 
                     result shouldNotBe null
-                    result.value shouldBe expectedMessage
+                    result.value shouldBe expected
                 }
             }
         }


### PR DESCRIPTION
Add [dead-letter-queue](https://en.wikipedia.org/wiki/Dead_letter_queue) mechanism to demonstrate the routing of faulty messages into a dedicated (optional) Kafka topic (`error`), quite similar to what was implemented in https://github.com/okp4/kafka-processor-cosmos-block/pull/6.