### PR TITLE
build: set projet name to the repository name

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 *
 
-!build/libs/kafka-processor-*-standalone.jar
+!build/libs/template-kafka-processor-*-standalone.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:11-jdk-slim
 
-COPY build/libs/kafka-processor-*-standalone.jar /opt/kafka-processor.jar
+COPY build/libs/template-kafka-processor-*-standalone.jar /opt/template-kafka-processor.jar
 
-ENTRYPOINT [ "java", "-jar", "/opt/kafka-processor.jar" ]
+ENTRYPOINT [ "java", "-jar", "/opt/template-kafka-processor.jar" ]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "kafka-processor"
+rootProject.name = "template-kafka-processor"


### PR DESCRIPTION
Set the gradle `project.name` to the repository name as it is used as maven publishing repository.